### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"stylelint": "^14.14.0",
 		"stylelint-config-standard": "^29.0.0",
 		"typescript": "^4.8.4",
-		"vite": "^3,.1.8",
+		"vite": "^3.1.8",
 		"vite-plugin-dts": "^1.6.6"
 	},
 	"eslintConfig": {


### PR DESCRIPTION
Invalid tag name "^3,.1.8" of package "vite@^3,.1.8": Tags may not have any characters that encodeURIComponent encodes.